### PR TITLE
Feat: Implement state persistence and reset for calculators

### DIFF
--- a/src/app/features/SureBetCalculator2Way/SureBetCalculator2Way.tsx
+++ b/src/app/features/SureBetCalculator2Way/SureBetCalculator2Way.tsx
@@ -1,122 +1,164 @@
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
 import { useSurebet2Way } from "@/app/hooks/useSurebet2Way";
 import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import BetSaveSection from "@/app/components/BetSaveSection";
 import OddsStakeRow from "@/app/components/OddsStakeRow";
 import TotalStakeRow from "@/app/components/TotalStakeRow";
 import ProfitDisplay from "@/app/components/ProfitDisplay";
 import CalculatorHeader from "@/app/components/CalculatorHeader";
-
 import { StakeField2Way } from "@/app/types/surebet";
+import { CalculatorState2Way } from "@/app/page"; // Importáljuk a közös állapot típust
 
 interface SureBetCalculator2WayProps {
   initialParams?: Record<string, string>;
+  calculatorState: CalculatorState2Way;
+  setCalculatorState: React.Dispatch<React.SetStateAction<CalculatorState2Way>>;
+  resetCalculatorState: () => void;
 }
 
-const SureBetCalculator2Way: React.FC<SureBetCalculator2WayProps> = ({ initialParams }) => {
-    const [odds1, setOdds1] = useState("2");
-    const [odds2, setOdds2] = useState("2");
-    const [odds1Type, setOdds1Type] = useState("");
-    const [odds2Type, setOdds2Type] = useState("");
-    const [totalStake, setTotalStake] = useState("10000");
-    const [stake1, setStake1] = useState(0);
-    const [stake2, setStake2] = useState(0);
-    const [fixedField, setFixedField] = useState<StakeField2Way>('total');
-    const [name, setName] = useState("");
+const SureBetCalculator2Way: React.FC<SureBetCalculator2WayProps> = ({
+  initialParams,
+  calculatorState,
+  setCalculatorState,
+  resetCalculatorState,
+}) => {
+  const {
+    odds1,
+    odds2,
+    odds1Type,
+    odds2Type,
+    totalStake,
+    stake1,
+    stake2,
+    fixedField,
+    name,
+  } = calculatorState;
 
-    // initialParams feldolgozása mountkor
-    useEffect(() => {
-        if (!initialParams) return;
-        if (initialParams.odds1) setOdds1(initialParams.odds1);
-        if (initialParams.odds2) setOdds2(initialParams.odds2);
-        if (initialParams.stake1) setStake1(Number(initialParams.stake1));
-        if (initialParams.stake2) setStake2(Number(initialParams.stake2));
-        if (initialParams.name) setName(initialParams.name);
-        setFixedField('stake1');
-    }, [initialParams]);
+  // Wrapper függvények az állapotfrissítéshez, hogy a setCalculatorState-et használjuk
+  const setOdds1 = (value: string) => setCalculatorState(prev => ({ ...prev, odds1: value }));
+  const setOdds2 = (value: string) => setCalculatorState(prev => ({ ...prev, odds2: value }));
+  const setOdds1Type = (value: string) => setCalculatorState(prev => ({ ...prev, odds1Type: value }));
+  const setOdds2Type = (value: string) => setCalculatorState(prev => ({ ...prev, odds2Type: value }));
+  const setTotalStake = (value: string) => setCalculatorState(prev => ({ ...prev, totalStake: value, fixedField: 'total' }));
+  const setStake1 = (value: number) => setCalculatorState(prev => ({ ...prev, stake1: value, fixedField: 'stake1' }));
+  const setStake2 = (value: number) => setCalculatorState(prev => ({ ...prev, stake2: value, fixedField: 'stake2' }));
+  const setFixedField = (value: StakeField2Way) => setCalculatorState(prev => ({ ...prev, fixedField: value }));
+  const setName = (value: string) => setCalculatorState(prev => ({ ...prev, name: value }));
 
-    // Kalkulációk kiszervezve hook-ba
-    const { stake1: calcStake1, stake2: calcStake2, totalStake: calcTotalStake, profit, profitPercentage } = useSurebet2Way({
-        odds1,
-        odds2,
-        totalStake,
-        stake1,
-        stake2,
-        fixedField,
-    });
 
-    // Segédfüggvény a bet visszatöltéséhez
-    const setFieldsFromBet = (bet: any) => {
-        setOdds1(bet.odds1);
-        setOdds2(bet.odds2);
-        setOdds1Type(bet.odds1Type);
-        setOdds2Type(bet.odds2Type);
-        setStake1(bet.stake1);
-        setStake2(bet.stake2);
-        setTotalStake(bet.totalStake);
-        setFixedField(bet.fixedField);
-    }; // Ez így maradhat, mert a hook automatikusan újraszámol mindent.
+  // initialParams feldolgozása mountkor vagy amikor initialParams megváltozik
+  useEffect(() => {
+    if (!initialParams) return;
 
-    return (
-        <Card className="w-full max-w-md mx-auto">
-            <CalculatorHeader title="2-Way Calculator" value={profitPercentage} />
-            <CardContent className="relative grid gap-4">
-                <OddsStakeRow
-                    oddsType={odds1Type}
-                    setOddsType={setOdds1Type}
-                    odds={odds1}
-                    setOdds={setOdds1}
-                    stake={calcStake1}
-                    setStake={setStake1}
-                    labelOdds="Odds 1"
-                    labelStake="Stake 1"
-                    oddsId="odds1"
-                    stakeId="stake1"
-                    fixedField={fixedField}
-                    setFixedField={setFixedField}
-                    stakeFieldName="stake1"
-                />
-                <OddsStakeRow
-                    oddsType={odds2Type}
-                    setOddsType={setOdds2Type}
-                    odds={odds2}
-                    setOdds={setOdds2}
-                    stake={calcStake2}
-                    setStake={setStake2}
-                    labelOdds="Odds 2"
-                    labelStake="Stake 2"
-                    oddsId="odds2"
-                    stakeId="stake2"
-                    fixedField={fixedField}
-                    setFixedField={setFixedField}
-                    stakeFieldName="stake2"
-                />
-                <TotalStakeRow
-                    totalStake={calcTotalStake}
-                    setTotalStake={setTotalStake}
-                    fixedField={fixedField}
-                    setFixedField={setFixedField}
-                />
-                <ProfitDisplay profit={profit} />
-                <BetSaveSection
-                    betFields={{
-                        odds1,
-                        odds2,
-                        odds1Type,
-                        odds2Type,
-                        stake1: calcStake1,
-                        stake2: calcStake2,
-                        totalStake: calcTotalStake,
-                        fixedField
-                    }}
-                    betName={name}
-                    setBetName={setName}
-                    storageKey="savedBets2Way"
-                    setFieldsFromBet={setFieldsFromBet}
-                />
-            </CardContent>
-        </Card>
-    );
+    let newState = { ...calculatorState };
+    if (initialParams.odds1) newState.odds1 = initialParams.odds1;
+    if (initialParams.odds2) newState.odds2 = initialParams.odds2;
+    // oddsType-okat nem kezelünk initialParams-ból, mert azok mentés specifikusak
+    if (initialParams.stake1) newState.stake1 = Number(initialParams.stake1);
+    if (initialParams.stake2) newState.stake2 = Number(initialParams.stake2);
+    if (initialParams.name) newState.name = initialParams.name;
+    // Ha tét van megadva, akkor az legyen a fixált, egyébként a totalStake
+    if (initialParams.stake1 || initialParams.stake2) {
+        newState.fixedField = initialParams.stake1 ? 'stake1' : 'stake2';
+    } else if (initialParams.totalStake) {
+        newState.totalStake = initialParams.totalStake;
+        newState.fixedField = 'total';
+    }
+    setCalculatorState(newState);
+  }, [initialParams]); // Figyeljünk az initialParams változására
+
+
+  const { stake1: calcStake1, stake2: calcStake2, totalStake: calcTotalStake, profit, profitPercentage } = useSurebet2Way({
+    odds1,
+    odds2,
+    totalStake,
+    stake1,
+    stake2,
+    fixedField,
+  });
+
+  // Segédfüggvény a bet visszatöltéséhez
+  const setFieldsFromBet = (bet: any) => {
+    setCalculatorState(prev => ({
+        ...prev,
+        odds1: bet.odds1,
+        odds2: bet.odds2,
+        odds1Type: bet.odds1Type || "", // Biztosítjuk, hogy string legyen
+        odds2Type: bet.odds2Type || "", // Biztosítjuk, hogy string legyen
+        stake1: Number(bet.stake1) || 0,
+        stake2: Number(bet.stake2) || 0,
+        totalStake: String(bet.totalStake) || "0",
+        fixedField: bet.fixedField,
+        name: bet.name || prev.name // Ha a bet tartalmaz nevet, azt használjuk, egyébként a régit
+    }));
+  };
+
+  return (
+    <Card className="w-full max-w-md mx-auto">
+      <CalculatorHeader title="2-Way Calculator" value={profitPercentage} />
+      <CardContent className="relative grid gap-4 pt-4">
+        <OddsStakeRow
+          oddsType={odds1Type}
+          setOddsType={setOdds1Type}
+          odds={odds1}
+          setOdds={setOdds1}
+          stake={calcStake1}
+          setStake={setStake1}
+          labelOdds="Odds 1"
+          labelStake="Stake 1"
+          oddsId="odds1-2way"
+          stakeId="stake1-2way"
+          fixedField={fixedField}
+          setFixedField={setFixedField}
+          stakeFieldName="stake1"
+        />
+        <OddsStakeRow
+          oddsType={odds2Type}
+          setOddsType={setOdds2Type}
+          odds={odds2}
+          setOdds={setOdds2}
+          stake={calcStake2}
+          setStake={setStake2}
+          labelOdds="Odds 2"
+          labelStake="Stake 2"
+          oddsId="odds2-2way"
+          stakeId="stake2-2way"
+          fixedField={fixedField}
+          setFixedField={setFixedField}
+          stakeFieldName="stake2"
+        />
+        <TotalStakeRow
+          totalStake={calcTotalStake}
+          setTotalStake={setTotalStake}
+          fixedField={fixedField}
+          setFixedField={setFixedField}
+        />
+        <ProfitDisplay profit={profit} />
+        <div className="flex justify-end">
+            <Button onClick={resetCalculatorState} variant="outline" size="sm">
+                Reset
+            </Button>
+        </div>
+        <BetSaveSection
+          betFields={{
+            odds1,
+            odds2,
+            odds1Type,
+            odds2Type,
+            stake1: calcStake1,
+            stake2: calcStake2,
+            totalStake: calcTotalStake,
+            fixedField,
+          }}
+          betName={name}
+          setBetName={setName}
+          storageKey="savedBets2Way"
+          setFieldsFromBet={setFieldsFromBet}
+        />
+      </CardContent>
+    </Card>
+  );
 };
 
 export default SureBetCalculator2Way;

--- a/src/app/features/SureBetCalculator3Way/SureBetCalculator3Way.tsx
+++ b/src/app/features/SureBetCalculator3Way/SureBetCalculator3Way.tsx
@@ -1,149 +1,149 @@
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
 import { useSurebet3Way } from "@/app/hooks/useSurebet3Way";
 import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import BetSaveSection from "@/app/components/BetSaveSection";
 import OddsStakeRow from "@/app/components/OddsStakeRow";
 import TotalStakeRow from "@/app/components/TotalStakeRow";
 import ProfitDisplay from "@/app/components/ProfitDisplay";
 import CalculatorHeader from "@/app/components/CalculatorHeader";
 import { StakeField3Way } from "@/app/types/surebet";
+import { CalculatorState3Way } from "@/app/page";
 
 interface SureBetCalculator3WayProps {
   initialParams?: Record<string, string>;
+  calculatorState: CalculatorState3Way;
+  setCalculatorState: React.Dispatch<React.SetStateAction<CalculatorState3Way>>;
+  resetCalculatorState: () => void;
 }
 
-const SureBetCalculator3Way: React.FC<SureBetCalculator3WayProps> = ({ initialParams }) => {
-    const [fixedField, setFixedField] = useState<StakeField3Way>('total');
-    const [odds1, setOdds1] = useState("3");
-    const [odds2, setOdds2] = useState("3");
-    const [odds3, setOdds3] = useState("3");
-    const [odds1Type, setOdds1Type] = useState("");
-    const [odds2Type, setOdds2Type] = useState("");
-    const [odds3Type, setOdds3Type] = useState("");
-    const [totalStake, setTotalStake] = useState("10000");
-    const [stake1, setStake1] = useState(0);
-    const [stake2, setStake2] = useState(0);
-    const [stake3, setStake3] = useState(0);
-    const [name, setName] = useState("");
+const SureBetCalculator3Way: React.FC<SureBetCalculator3WayProps> = ({
+  initialParams,
+  calculatorState,
+  setCalculatorState,
+  resetCalculatorState,
+}) => {
+  const {
+    odds1, odds2, odds3,
+    odds1Type, odds2Type, odds3Type,
+    totalStake,
+    stake1, stake2, stake3,
+    fixedField, name
+  } = calculatorState;
 
-    // initialParams feldolgozása mountkor
-    useEffect(() => {
-        if (!initialParams) return;
-        if (initialParams.odds1) setOdds1(initialParams.odds1);
-        if (initialParams.odds2) setOdds2(initialParams.odds2);
-        if (initialParams.odds3) setOdds3(initialParams.odds3);
-        if (initialParams.stake1) setStake1(Number(initialParams.stake1));
-        if (initialParams.stake2) setStake2(Number(initialParams.stake2));
-        if (initialParams.stake3) setStake3(Number(initialParams.stake3));
-        if (initialParams.name) setName(initialParams.name);
-        setFixedField('stake1');
-    }, [initialParams]);
+  const setOdds1 = (value: string) => setCalculatorState(prev => ({ ...prev, odds1: value }));
+  const setOdds2 = (value: string) => setCalculatorState(prev => ({ ...prev, odds2: value }));
+  const setOdds3 = (value: string) => setCalculatorState(prev => ({ ...prev, odds3: value }));
+  const setOdds1Type = (value: string) => setCalculatorState(prev => ({ ...prev, odds1Type: value }));
+  const setOdds2Type = (value: string) => setCalculatorState(prev => ({ ...prev, odds2Type: value }));
+  const setOdds3Type = (value: string) => setCalculatorState(prev => ({ ...prev, odds3Type: value }));
+  const setTotalStake = (value: string) => setCalculatorState(prev => ({ ...prev, totalStake: value, fixedField: 'total' }));
+  const setStake1 = (value: number) => setCalculatorState(prev => ({ ...prev, stake1: value, fixedField: 'stake1' }));
+  const setStake2 = (value: number) => setCalculatorState(prev => ({ ...prev, stake2: value, fixedField: 'stake2' }));
+  const setStake3 = (value: number) => setCalculatorState(prev => ({ ...prev, stake3: value, fixedField: 'stake3' }));
+  const setFixedField = (value: StakeField3Way) => setCalculatorState(prev => ({ ...prev, fixedField: value }));
+  const setName = (value: string) => setCalculatorState(prev => ({ ...prev, name: value }));
 
-    // Kalkulációk kiszervezve hook-ba
-    const { stake1: calcStake1, stake2: calcStake2, stake3: calcStake3, totalStake: calcTotalStake, profit, profitPercentage } = useSurebet3Way({
-        odds1,
-        odds2,
-        odds3,
-        totalStake,
-        stake1,
-        stake2,
-        stake3,
-        fixedField,
-    });
+  useEffect(() => {
+    if (!initialParams) return;
+    let newState = { ...calculatorState };
+    if (initialParams.odds1) newState.odds1 = initialParams.odds1;
+    if (initialParams.odds2) newState.odds2 = initialParams.odds2;
+    if (initialParams.odds3) newState.odds3 = initialParams.odds3;
+    if (initialParams.stake1) newState.stake1 = Number(initialParams.stake1);
+    if (initialParams.stake2) newState.stake2 = Number(initialParams.stake2);
+    if (initialParams.stake3) newState.stake3 = Number(initialParams.stake3);
+    if (initialParams.name) newState.name = initialParams.name;
+    if (initialParams.stake1 || initialParams.stake2 || initialParams.stake3) {
+        newState.fixedField = initialParams.stake1 ? 'stake1' : initialParams.stake2 ? 'stake2' : 'stake3';
+    } else if (initialParams.totalStake) {
+        newState.totalStake = initialParams.totalStake;
+        newState.fixedField = 'total';
+    }
+    setCalculatorState(newState);
+  }, [initialParams]);
 
-    // Segédfüggvény a bet visszatöltéséhez
-    const setFieldsFromBet = (bet: any) => {
-        setOdds1(bet.odds1);
-        setOdds2(bet.odds2);
-        setOdds3(bet.odds3);
-        setOdds1Type(bet.odds1Type);
-        setOdds2Type(bet.odds2Type);
-        setOdds3Type(bet.odds3Type);
-        setStake1(bet.stake1);
-        setStake2(bet.stake2);
-        setStake3(bet.stake3);
-        setTotalStake(bet.totalStake);
-        setFixedField(bet.fixedField);
-    }; // A hook automatikusan újraszámol mindent.
+  const { stake1: calcStake1, stake2: calcStake2, stake3: calcStake3, totalStake: calcTotalStake, profit, profitPercentage } = useSurebet3Way({
+    odds1, odds2, odds3,
+    totalStake,
+    stake1, stake2, stake3,
+    fixedField,
+  });
 
-    return (
-        <Card className="w-full max-w-md mx-auto">
-            <CalculatorHeader title="3-Way Calculator" value={profitPercentage} />
-            <CardContent className="relative grid gap-4">
-                <OddsStakeRow<StakeField3Way>
-                    oddsType={odds1Type}
-                    setOddsType={setOdds1Type}
-                    odds={odds1}
-                    setOdds={setOdds1}
-                    stake={calcStake1}
-                    setStake={setStake1}
-                    labelOdds="Odds 1"
-                    labelStake="Stake 1"
-                    oddsId="odds1"
-                    stakeId="stake1"
-                    fixedField={fixedField}
-                    setFixedField={setFixedField}
-                    stakeFieldName="stake1"
-                />
-                <OddsStakeRow<StakeField3Way>
-                    oddsType={odds2Type}
-                    setOddsType={setOdds2Type}
-                    odds={odds2}
-                    setOdds={setOdds2}
-                    stake={calcStake2}
-                    setStake={setStake2}
-                    labelOdds="Odds 2"
-                    labelStake="Stake 2"
-                    oddsId="odds2"
-                    stakeId="stake2"
-                    fixedField={fixedField}
-                    setFixedField={setFixedField}
-                    stakeFieldName="stake2"
-                />
-                <OddsStakeRow<StakeField3Way>
-                    oddsType={odds3Type}
-                    setOddsType={setOdds3Type}
-                    odds={odds3}
-                    setOdds={setOdds3}
-                    stake={calcStake3}
-                    setStake={setStake3}
-                    labelOdds="Odds 3"
-                    labelStake="Stake 3"
-                    oddsId="odds3"
-                    stakeId="stake3"
-                    fixedField={fixedField}
-                    setFixedField={setFixedField}
-                    stakeFieldName="stake3"
-                />
-                <TotalStakeRow
-                    totalStake={calcTotalStake}
-                    setTotalStake={setTotalStake}
-                    fixedField={fixedField}
-                    setFixedField={setFixedField}
-                />
-                <ProfitDisplay profit={profit} />
-                <BetSaveSection
-                    betFields={{
-                        odds1,
-                        odds2,
-                        odds3,
-                        odds1Type,
-                        odds2Type,
-                        odds3Type,
-                        stake1: calcStake1,
-                        stake2: calcStake2,
-                        stake3: calcStake3,
-                        totalStake: calcTotalStake,
-                        fixedField
-                    }}
-                    betName={name}
-                    setBetName={setName}
-                    storageKey="savedBets3Way"
-                    setFieldsFromBet={setFieldsFromBet}
-                />
-            </CardContent>
-        </Card>
-    );
+  const setFieldsFromBet = (bet: any) => {
+    setCalculatorState(prev => ({
+        ...prev,
+        odds1: bet.odds1,
+        odds2: bet.odds2,
+        odds3: bet.odds3,
+        odds1Type: bet.odds1Type || "",
+        odds2Type: bet.odds2Type || "",
+        odds3Type: bet.odds3Type || "",
+        stake1: Number(bet.stake1) || 0,
+        stake2: Number(bet.stake2) || 0,
+        stake3: Number(bet.stake3) || 0,
+        totalStake: String(bet.totalStake) || "0",
+        fixedField: bet.fixedField,
+        name: bet.name || prev.name
+    }));
+  };
+
+  return (
+    <Card className="w-full max-w-md mx-auto">
+      <CalculatorHeader title="3-Way Calculator" value={profitPercentage} />
+      <CardContent className="relative grid gap-4 pt-4">
+        <OddsStakeRow<StakeField3Way>
+          oddsType={odds1Type} setOddsType={setOdds1Type}
+          odds={odds1} setOdds={setOdds1}
+          stake={calcStake1} setStake={setStake1}
+          labelOdds="Odds 1" labelStake="Stake 1"
+          oddsId="odds1-3way" stakeId="stake1-3way"
+          fixedField={fixedField} setFixedField={setFixedField}
+          stakeFieldName="stake1"
+        />
+        <OddsStakeRow<StakeField3Way>
+          oddsType={odds2Type} setOddsType={setOdds2Type}
+          odds={odds2} setOdds={setOdds2}
+          stake={calcStake2} setStake={setStake2}
+          labelOdds="Odds 2" labelStake="Stake 2"
+          oddsId="odds2-3way" stakeId="stake2-3way"
+          fixedField={fixedField} setFixedField={setFixedField}
+          stakeFieldName="stake2"
+        />
+        <OddsStakeRow<StakeField3Way>
+          oddsType={odds3Type} setOddsType={setOdds3Type}
+          odds={odds3} setOdds={setOdds3}
+          stake={calcStake3} setStake={setStake3}
+          labelOdds="Odds 3" labelStake="Stake 3"
+          oddsId="odds3-3way" stakeId="stake3-3way"
+          fixedField={fixedField} setFixedField={setFixedField}
+          stakeFieldName="stake3"
+        />
+        <TotalStakeRow
+          totalStake={calcTotalStake} setTotalStake={setTotalStake}
+          fixedField={fixedField} setFixedField={setFixedField}
+        />
+        <ProfitDisplay profit={profit} />
+        <div className="flex justify-end">
+            <Button onClick={resetCalculatorState} variant="outline" size="sm">
+                Reset
+            </Button>
+        </div>
+        <BetSaveSection
+          betFields={{
+            odds1, odds2, odds3,
+            odds1Type, odds2Type, odds3Type,
+            stake1: calcStake1, stake2: calcStake2, stake3: calcStake3,
+            totalStake: calcTotalStake,
+            fixedField
+          }}
+          betName={name} setBetName={setName}
+          storageKey="savedBets3Way"
+          setFieldsFromBet={setFieldsFromBet}
+        />
+      </CardContent>
+    </Card>
+  );
 };
 
 export default SureBetCalculator3Way;

--- a/src/app/features/SureBetCalculator4Way/SureBetCalculator4Way.tsx
+++ b/src/app/features/SureBetCalculator4Way/SureBetCalculator4Way.tsx
@@ -1,178 +1,166 @@
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
 import { useSurebet4Way } from "@/app/hooks/useSurebet4Way";
 import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import BetSaveSection from "@/app/components/BetSaveSection";
 import OddsStakeRow from "@/app/components/OddsStakeRow";
 import TotalStakeRow from "@/app/components/TotalStakeRow";
 import ProfitDisplay from "@/app/components/ProfitDisplay";
 import CalculatorHeader from "@/app/components/CalculatorHeader";
-
 import { StakeField4Way } from "@/app/types/surebet";
+import { CalculatorState4Way } from "@/app/page";
 
 interface SureBetCalculator4WayProps {
   initialParams?: Record<string, string>;
+  calculatorState: CalculatorState4Way;
+  setCalculatorState: React.Dispatch<React.SetStateAction<CalculatorState4Way>>;
+  resetCalculatorState: () => void;
 }
 
-const SureBetCalculator4Way: React.FC<SureBetCalculator4WayProps> = ({ initialParams }) => {
-    const [fixedField, setFixedField] = useState<StakeField4Way>('total');
-    const [odds1, setOdds1] = useState("4");
-    const [odds2, setOdds2] = useState("4");
-    const [odds3, setOdds3] = useState("4");
-    const [odds4, setOdds4] = useState("4");
-    const [odds1Type, setOdds1Type] = useState("");
-    const [odds2Type, setOdds2Type] = useState("");
-    const [odds3Type, setOdds3Type] = useState("");
-    const [odds4Type, setOdds4Type] = useState("");
-    const [totalStake, setTotalStake] = useState("10000");
-    const [stake1, setStake1] = useState(0);
-    const [stake2, setStake2] = useState(0);
-    const [stake3, setStake3] = useState(0);
-    const [stake4, setStake4] = useState(0);
-    const [name, setName] = useState("");
+const SureBetCalculator4Way: React.FC<SureBetCalculator4WayProps> = ({
+  initialParams,
+  calculatorState,
+  setCalculatorState,
+  resetCalculatorState,
+}) => {
+  const {
+    odds1, odds2, odds3, odds4,
+    odds1Type, odds2Type, odds3Type, odds4Type,
+    totalStake,
+    stake1, stake2, stake3, stake4,
+    fixedField, name
+  } = calculatorState;
 
-    // initialParams feldolgozása mountkor
-    useEffect(() => {
-        if (!initialParams) return;
-        if (initialParams.odds1) setOdds1(initialParams.odds1);
-        if (initialParams.odds2) setOdds2(initialParams.odds2);
-        if (initialParams.odds3) setOdds3(initialParams.odds3);
-        if (initialParams.odds4) setOdds4(initialParams.odds4);
-        if (initialParams.stake1) setStake1(Number(initialParams.stake1));
-        if (initialParams.stake2) setStake2(Number(initialParams.stake2));
-        if (initialParams.stake3) setStake3(Number(initialParams.stake3));
-        if (initialParams.stake4) setStake4(Number(initialParams.stake4));
-        if (initialParams.name) setName(initialParams.name);
-        setFixedField('stake1');
-    }, [initialParams]);
+  const setOdds1 = (value: string) => setCalculatorState(prev => ({ ...prev, odds1: value }));
+  const setOdds2 = (value: string) => setCalculatorState(prev => ({ ...prev, odds2: value }));
+  const setOdds3 = (value: string) => setCalculatorState(prev => ({ ...prev, odds3: value }));
+  const setOdds4 = (value: string) => setCalculatorState(prev => ({ ...prev, odds4: value }));
+  const setOdds1Type = (value: string) => setCalculatorState(prev => ({ ...prev, odds1Type: value }));
+  const setOdds2Type = (value: string) => setCalculatorState(prev => ({ ...prev, odds2Type: value }));
+  const setOdds3Type = (value: string) => setCalculatorState(prev => ({ ...prev, odds3Type: value }));
+  const setOdds4Type = (value: string) => setCalculatorState(prev => ({ ...prev, odds4Type: value }));
+  const setTotalStake = (value: string) => setCalculatorState(prev => ({ ...prev, totalStake: value, fixedField: 'total' }));
+  const setStake1 = (value: number) => setCalculatorState(prev => ({ ...prev, stake1: value, fixedField: 'stake1' }));
+  const setStake2 = (value: number) => setCalculatorState(prev => ({ ...prev, stake2: value, fixedField: 'stake2' }));
+  const setStake3 = (value: number) => setCalculatorState(prev => ({ ...prev, stake3: value, fixedField: 'stake3' }));
+  const setStake4 = (value: number) => setCalculatorState(prev => ({ ...prev, stake4: value, fixedField: 'stake4' }));
+  const setFixedField = (value: StakeField4Way) => setCalculatorState(prev => ({ ...prev, fixedField: value }));
+  const setName = (value: string) => setCalculatorState(prev => ({ ...prev, name: value }));
 
-    // Kalkulációk kiszervezve hook-ba
-    const { stake1: calcStake1, stake2: calcStake2, stake3: calcStake3, stake4: calcStake4, totalStake: calcTotalStake, profit, profitPercentage } = useSurebet4Way({
-        odds1,
-        odds2,
-        odds3,
-        odds4,
-        totalStake,
-        stake1,
-        stake2,
-        stake3,
-        stake4,
-        fixedField,
-    });
+  useEffect(() => {
+    if (!initialParams) return;
+    let newState = { ...calculatorState };
+    if (initialParams.odds1) newState.odds1 = initialParams.odds1;
+    if (initialParams.odds2) newState.odds2 = initialParams.odds2;
+    if (initialParams.odds3) newState.odds3 = initialParams.odds3;
+    if (initialParams.odds4) newState.odds4 = initialParams.odds4;
+    if (initialParams.stake1) newState.stake1 = Number(initialParams.stake1);
+    if (initialParams.stake2) newState.stake2 = Number(initialParams.stake2);
+    if (initialParams.stake3) newState.stake3 = Number(initialParams.stake3);
+    if (initialParams.stake4) newState.stake4 = Number(initialParams.stake4);
+    if (initialParams.name) newState.name = initialParams.name;
+    if (initialParams.stake1 || initialParams.stake2 || initialParams.stake3 || initialParams.stake4) {
+        newState.fixedField = initialParams.stake1 ? 'stake1' : initialParams.stake2 ? 'stake2' : initialParams.stake3 ? 'stake3' : 'stake4';
+    } else if (initialParams.totalStake) {
+        newState.totalStake = initialParams.totalStake;
+        newState.fixedField = 'total';
+    }
+    setCalculatorState(newState);
+  }, [initialParams]);
 
-    // Segédfüggvény a bet visszatöltéséhez
-    const setFieldsFromBet = (bet: any) => {
-        setOdds1(bet.odds1);
-        setOdds2(bet.odds2);
-        setOdds3(bet.odds3);
-        setOdds4(bet.odds4);
-        setOdds1Type(bet.odds1Type);
-        setOdds2Type(bet.odds2Type);
-        setOdds3Type(bet.odds3Type);
-        setOdds4Type(bet.odds4Type);
-        setStake1(bet.stake1);
-        setStake2(bet.stake2);
-        setStake3(bet.stake3);
-        setStake4(bet.stake4);
-        setTotalStake(bet.totalStake);
-        setFixedField(bet.fixedField);
-    };
+  const { stake1: calcStake1, stake2: calcStake2, stake3: calcStake3, stake4: calcStake4, totalStake: calcTotalStake, profit, profitPercentage } = useSurebet4Way({
+    odds1, odds2, odds3, odds4,
+    totalStake,
+    stake1, stake2, stake3, stake4,
+    fixedField,
+  });
 
-    return (
-        <Card className="w-full max-w-md mx-auto">
-            <CalculatorHeader title="4-Way Calculator" value={profitPercentage} />
-            <CardContent className="relative grid gap-4">
-                <OddsStakeRow<StakeField4Way>
-                    oddsType={odds1Type}
-                    setOddsType={setOdds1Type}
-                    odds={odds1}
-                    setOdds={setOdds1}
-                    stake={calcStake1}
-                    setStake={setStake1}
-                    labelOdds="Odds 1"
-                    labelStake="Stake 1"
-                    oddsId="odds1"
-                    stakeId="stake1"
-                    fixedField={fixedField}
-                    setFixedField={setFixedField}
-                    stakeFieldName="stake1"
-                />
-                <OddsStakeRow<StakeField4Way>
-                    oddsType={odds2Type}
-                    setOddsType={setOdds2Type}
-                    odds={odds2}
-                    setOdds={setOdds2}
-                    stake={calcStake2}
-                    setStake={setStake2}
-                    labelOdds="Odds 2"
-                    labelStake="Stake 2"
-                    oddsId="odds2"
-                    stakeId="stake2"
-                    fixedField={fixedField}
-                    setFixedField={setFixedField}
-                    stakeFieldName="stake2"
-                />
-                <OddsStakeRow<StakeField4Way>
-                    oddsType={odds3Type}
-                    setOddsType={setOdds3Type}
-                    odds={odds3}
-                    setOdds={setOdds3}
-                    stake={calcStake3}
-                    setStake={setStake3}
-                    labelOdds="Odds 3"
-                    labelStake="Stake 3"
-                    oddsId="odds3"
-                    stakeId="stake3"
-                    fixedField={fixedField}
-                    setFixedField={setFixedField}
-                    stakeFieldName="stake3"
-                />
-                <OddsStakeRow<StakeField4Way>
-                    oddsType={odds4Type}
-                    setOddsType={setOdds4Type}
-                    odds={odds4}
-                    setOdds={setOdds4}
-                    stake={calcStake4}
-                    setStake={setStake4}
-                    labelOdds="Odds 4"
-                    labelStake="Stake 4"
-                    oddsId="odds4"
-                    stakeId="stake4"
-                    fixedField={fixedField}
-                    setFixedField={setFixedField}
-                    stakeFieldName="stake4"
-                />
-                <TotalStakeRow
-                    totalStake={calcTotalStake}
-                    setTotalStake={setTotalStake}
-                    fixedField={fixedField}
-                    setFixedField={setFixedField}
-                />
-                <ProfitDisplay profit={profit} />
-                <BetSaveSection
-                    betFields={{
-                        odds1,
-                        odds2,
-                        odds3,
-                        odds4,
-                        odds1Type,
-                        odds2Type,
-                        odds3Type,
-                        odds4Type,
-                        stake1: calcStake1,
-                        stake2: calcStake2,
-                        stake3: calcStake3,
-                        stake4: calcStake4,
-                        totalStake: calcTotalStake,
-                        fixedField
-                    }}
-                    betName={name}
-                    setBetName={setName}
-                    storageKey="savedBets4Way"
-                    setFieldsFromBet={setFieldsFromBet}
-                />
-            </CardContent>
-        </Card>
-    );
+  const setFieldsFromBet = (bet: any) => {
+    setCalculatorState(prev => ({
+        ...prev,
+        odds1: bet.odds1,
+        odds2: bet.odds2,
+        odds3: bet.odds3,
+        odds4: bet.odds4,
+        odds1Type: bet.odds1Type || "",
+        odds2Type: bet.odds2Type || "",
+        odds3Type: bet.odds3Type || "",
+        odds4Type: bet.odds4Type || "",
+        stake1: Number(bet.stake1) || 0,
+        stake2: Number(bet.stake2) || 0,
+        stake3: Number(bet.stake3) || 0,
+        stake4: Number(bet.stake4) || 0,
+        totalStake: String(bet.totalStake) || "0",
+        fixedField: bet.fixedField,
+        name: bet.name || prev.name
+    }));
+  };
+
+  return (
+    <Card className="w-full max-w-md mx-auto">
+      <CalculatorHeader title="4-Way Calculator" value={profitPercentage} />
+      <CardContent className="relative grid gap-4 pt-4">
+        <OddsStakeRow<StakeField4Way>
+          oddsType={odds1Type} setOddsType={setOdds1Type}
+          odds={odds1} setOdds={setOdds1}
+          stake={calcStake1} setStake={setStake1}
+          labelOdds="Odds 1" labelStake="Stake 1"
+          oddsId="odds1-4way" stakeId="stake1-4way"
+          fixedField={fixedField} setFixedField={setFixedField}
+          stakeFieldName="stake1"
+        />
+        <OddsStakeRow<StakeField4Way>
+          oddsType={odds2Type} setOddsType={setOdds2Type}
+          odds={odds2} setOdds={setOdds2}
+          stake={calcStake2} setStake={setStake2}
+          labelOdds="Odds 2" labelStake="Stake 2"
+          oddsId="odds2-4way" stakeId="stake2-4way"
+          fixedField={fixedField} setFixedField={setFixedField}
+          stakeFieldName="stake2"
+        />
+        <OddsStakeRow<StakeField4Way>
+          oddsType={odds3Type} setOddsType={setOdds3Type}
+          odds={odds3} setOdds={setOdds3}
+          stake={calcStake3} setStake={setStake3}
+          labelOdds="Odds 3" labelStake="Stake 3"
+          oddsId="odds3-4way" stakeId="stake3-4way"
+          fixedField={fixedField} setFixedField={setFixedField}
+          stakeFieldName="stake3"
+        />
+        <OddsStakeRow<StakeField4Way>
+          oddsType={odds4Type} setOddsType={setOdds4Type}
+          odds={odds4} setOdds={setOdds4}
+          stake={calcStake4} setStake={setStake4}
+          labelOdds="Odds 4" labelStake="Stake 4"
+          oddsId="odds4-4way" stakeId="stake4-4way"
+          fixedField={fixedField} setFixedField={setFixedField}
+          stakeFieldName="stake4"
+        />
+        <TotalStakeRow
+          totalStake={calcTotalStake} setTotalStake={setTotalStake}
+          fixedField={fixedField} setFixedField={setFixedField}
+        />
+        <ProfitDisplay profit={profit} />
+        <div className="flex justify-end">
+            <Button onClick={resetCalculatorState} variant="outline" size="sm">
+                Reset
+            </Button>
+        </div>
+        <BetSaveSection
+          betFields={{
+            odds1, odds2, odds3, odds4,
+            odds1Type, odds2Type, odds3Type, odds4Type,
+            stake1: calcStake1, stake2: calcStake2, stake3: calcStake3, stake4: calcStake4,
+            totalStake: calcTotalStake,
+            fixedField
+          }}
+          betName={name} setBetName={setName}
+          storageKey="savedBets4Way"
+          setFieldsFromBet={setFieldsFromBet}
+        />
+      </CardContent>
+    </Card>
+  );
 };
 
 export default SureBetCalculator4Way;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,33 +4,108 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import SureBetCalculator2Way from "./features/SureBetCalculator2Way";
 import SureBetCalculator3Way from "./features/SureBetCalculator3Way";
 import SureBetCalculator4Way from "./features/SureBetCalculator4Way";
+import { StakeField2Way, StakeField3Way, StakeField4Way } from "@/app/types/surebet";
 
 import { useEffect, useState } from "react";
+
+// Alapértelmezett állapotok definiálása
+const defaultCalculatorState2Way = {
+  odds1: "2",
+  odds2: "2",
+  odds1Type: "",
+  odds2Type: "",
+  totalStake: "10000",
+  stake1: 0,
+  stake2: 0,
+  fixedField: "total" as StakeField2Way,
+  name: "",
+};
+
+const defaultCalculatorState3Way = {
+  odds1: "3",
+  odds2: "3",
+  odds3: "3",
+  odds1Type: "",
+  odds2Type: "",
+  odds3Type: "",
+  totalStake: "10000",
+  stake1: 0,
+  stake2: 0,
+  stake3: 0,
+  fixedField: "total" as StakeField3Way,
+  name: "",
+};
+
+const defaultCalculatorState4Way = {
+  odds1: "4",
+  odds2: "4",
+  odds3: "4",
+  odds4: "4",
+  odds1Type: "",
+  odds2Type: "",
+  odds3Type: "",
+  odds4Type: "",
+  totalStake: "10000",
+  stake1: 0,
+  stake2: 0,
+  stake3: 0,
+  stake4: 0,
+  fixedField: "total" as StakeField4Way,
+  name: "",
+};
+
+export type CalculatorState2Way = typeof defaultCalculatorState2Way;
+export type CalculatorState3Way = typeof defaultCalculatorState3Way;
+export type CalculatorState4Way = typeof defaultCalculatorState4Way;
 
 export default function Home() {
   const [activeTab, setActiveTab] = useState("2-way");
   const [initialParams, setInitialParams] = useState<Record<string, string> | undefined>(undefined);
 
+  // Kalkulátorok állapotának közös kezelése
+  const [calculatorState2Way, setCalculatorState2Way] = useState<CalculatorState2Way>(defaultCalculatorState2Way);
+  const [calculatorState3Way, setCalculatorState3Way] = useState<CalculatorState3Way>(defaultCalculatorState3Way);
+  const [calculatorState4Way, setCalculatorState4Way] = useState<CalculatorState4Way>(defaultCalculatorState4Way);
+
   useEffect(() => {
     const params = Object.fromEntries(new URLSearchParams(window.location.search));
     const hasAny = Object.keys(params).length > 0;
     if (hasAny) {
-      setInitialParams(params);
+      setInitialParams(params); // Ezt továbbra is beállítjuk, hogy a kalkulátorok feldolgozhassák
       if (params.odds4) setActiveTab("4-way");
       else if (params.odds3) setActiveTab("3-way");
       else setActiveTab("2-way");
       window.history.replaceState({}, document.title, window.location.pathname);
     } else {
       setInitialParams(undefined);
-      setActiveTab("2-way");
+      // Alapértelmezett tab beállítása, ha nincsenek paraméterek
+      // setActiveTab("2-way"); // Ezt már a useState hook alapértelmezett értéke kezeli
     }
   }, []);
 
+  // Az initialParams feldolgozása és törlése, hogy ne befolyásolja a tabváltásokat
   useEffect(() => {
     if (initialParams) {
+      // Itt lehetne közvetlenül frissíteni a megfelelő kalkulátor állapotát az initialParams alapján,
+      // de egyszerűbb, ha ezt a kalkulátor komponensek maguk kezelik, ahogy eddig is.
+      // A lényeg, hogy az initialParams-t csak egyszer használjuk fel.
       setTimeout(() => setInitialParams(undefined), 0);
     }
   }, [initialParams]);
+
+  const resetCalculatorState = (calculatorType: '2-way' | '3-way' | '4-way') => {
+    switch (calculatorType) {
+      case '2-way':
+        setCalculatorState2Way(defaultCalculatorState2Way);
+        break;
+      case '3-way':
+        setCalculatorState3Way(defaultCalculatorState3Way);
+        break;
+      case '4-way':
+        setCalculatorState4Way(defaultCalculatorState4Way);
+        break;
+    }
+  };
 
   return (
     <div className="container mx-auto py-2">
@@ -47,25 +122,28 @@ export default function Home() {
           </TabsTrigger>
         </TabsList>
         <TabsContent value="2-way">
-          {activeTab === "2-way" && initialParams ? (
-            <SureBetCalculator2Way initialParams={initialParams} />
-          ) : (
-            <SureBetCalculator2Way />
-          )}
+          <SureBetCalculator2Way
+            initialParams={activeTab === "2-way" ? initialParams : undefined}
+            calculatorState={calculatorState2Way}
+            setCalculatorState={setCalculatorState2Way}
+            resetCalculatorState={() => resetCalculatorState('2-way')}
+          />
         </TabsContent>
         <TabsContent value="3-way">
-          {activeTab === "3-way" && initialParams ? (
-            <SureBetCalculator3Way initialParams={initialParams} />
-          ) : (
-            <SureBetCalculator3Way />
-          )}
+          <SureBetCalculator3Way
+            initialParams={activeTab === "3-way" ? initialParams : undefined}
+            calculatorState={calculatorState3Way}
+            setCalculatorState={setCalculatorState3Way}
+            resetCalculatorState={() => resetCalculatorState('3-way')}
+          />
         </TabsContent>
         <TabsContent value="4-way">
-          {activeTab === "4-way" && initialParams ? (
-            <SureBetCalculator4Way initialParams={initialParams} />
-          ) : (
-            <SureBetCalculator4Way />
-          )}
+          <SureBetCalculator4Way
+            initialParams={activeTab === "4-way" ? initialParams : undefined}
+            calculatorState={calculatorState4Way}
+            setCalculatorState={setCalculatorState4Way}
+            resetCalculatorState={() => resetCalculatorState('4-way')}
+          />
         </TabsContent>
       </Tabs>
     </div>


### PR DESCRIPTION
- Modified the main page to manage the state of 2-Way, 3-Way, and 4-Way calculators centrally.
- Calculator states are now preserved when switching between tabs.
- Added a 'Reset' button to each calculator to revert its state to default values.
- Updated calculator components to use the shared state and reset functionality.
- Ensured that URL parameter initialization still works correctly and does not interfere with tab switching state preservation.