### PR TITLE
Feat: Add reset button to calculator headers

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -6,11 +6,16 @@ export default {
   },
   moduleNameMapper: {
     '^@/components/(.*)$': '<rootDir>/src/components/$1',
+    '^@/app/components/(.*)$': '<rootDir>/src/app/components/$1',
+    '^@/app/hooks/(.*)$': '<rootDir>/src/app/hooks/$1', // Added this line
     '^@/lib/(.*)$': '<rootDir>/src/lib/$1',
     '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
     '\\.(gif|ttf|eot|svg|png)$': '<rootDir>/__mocks__/fileMock.js',
   },
   testPathIgnorePatterns: ['<rootDir>/.next/', '<rootDir>/node_modules/'],
+  transformIgnorePatterns: [ // Added to handle lucide-react
+    '/node_modules/(?!lucide-react)/',
+  ],
   moduleDirectories: ['node_modules', '<rootDir>/'],
   globals: {
     'ts-jest': {

--- a/src/app/components/CalculatorHeader.tsx
+++ b/src/app/components/CalculatorHeader.tsx
@@ -1,20 +1,30 @@
 import React from "react";
 
+// Removed duplicate React import
+import ResetButton from "./ResetButton"; // Import the new ResetButton component
+
 interface CalculatorHeaderProps {
   title: string;
   value: number;
   valueLabel?: string;
   className?: string;
+  onReset?: () => void; // Add the new onReset prop
 }
 
 const CalculatorHeader: React.FC<CalculatorHeaderProps> = ({
   title,
   value,
   valueLabel = "",
-  className = ""
+  className = "",
+  onReset, // Destructure the new prop
 }) => (
   <div className={`relative px-6 pt-6 pb-2 ${className}`}>
-    <h2 className="text-3xl font-bold mb-2 pr-32">{title}</h2>
+    <div className="flex items-center justify-between">
+      <h2 className="text-3xl font-bold mb-2 pr-4">{title}</h2> {/* Reduced pr for spacing */}
+      {onReset && (
+        <ResetButton onClick={onReset} className="mb-2" /> // Render ResetButton if onReset is provided
+      )}
+    </div>
     <div className="absolute top-6 right-8 text-sm" style={{ color: value >= 0 ? 'green' : 'red' }}>
       {valueLabel ? `${valueLabel}: ` : null}{value.toFixed(2)}%
     </div>

--- a/src/app/components/ResetButton.tsx
+++ b/src/app/components/ResetButton.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import { XIcon } from 'lucide-react';
+
+interface ResetButtonProps {
+  onClick: () => void;
+  className?: string;
+}
+
+const ResetButton: React.FC<ResetButtonProps> = ({ onClick, className = "" }) => {
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className={`rounded-full ${className}`}
+      onClick={onClick}
+      aria-label="Reset"
+    >
+      <XIcon className="h-5 w-5" />
+    </Button>
+  );
+};
+
+export default ResetButton;

--- a/src/app/components/__tests__/CalculatorHeader.test.tsx
+++ b/src/app/components/__tests__/CalculatorHeader.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import CalculatorHeader from '../CalculatorHeader';
+import '@testing-library/jest-dom';
+
+// Mock the ResetButton to simplify testing CalculatorHeader's logic
+jest.mock('../ResetButton', () => {
+  return jest.fn(({ onClick }) => (
+    <button aria-label="Reset" onClick={onClick}>MockReset</button>
+  ));
+});
+
+describe('CalculatorHeader', () => {
+  const defaultProps = {
+    title: 'Test Calculator',
+    value: 10.5,
+  };
+
+  it('renders title and value correctly', () => {
+    render(<CalculatorHeader {...defaultProps} />);
+    expect(screen.getByText('Test Calculator')).toBeInTheDocument();
+    expect(screen.getByText(/10.50%/i)).toBeInTheDocument();
+  });
+
+  it('renders valueLabel when provided', () => {
+    render(<CalculatorHeader {...defaultProps} valueLabel="Profit" />);
+    expect(screen.getByText(/Profit: 10.50%/i)).toBeInTheDocument();
+  });
+
+  it('does not render ResetButton when onReset is not provided', () => {
+    render(<CalculatorHeader {...defaultProps} />);
+    expect(screen.queryByRole('button', { name: /reset/i })).not.toBeInTheDocument();
+  });
+
+  it('renders ResetButton when onReset is provided', () => {
+    const handleReset = jest.fn();
+    render(<CalculatorHeader {...defaultProps} onReset={handleReset} />);
+    const resetButton = screen.getByRole('button', { name: /reset/i });
+    expect(resetButton).toBeInTheDocument();
+    expect(resetButton).toHaveTextContent('MockReset'); // Check content of the mocked button
+  });
+
+  it('calls onReset when ResetButton is clicked', () => {
+    const handleReset = jest.fn();
+    render(<CalculatorHeader {...defaultProps} onReset={handleReset} />);
+    const resetButton = screen.getByRole('button', { name: /reset/i });
+    fireEvent.click(resetButton);
+    expect(handleReset).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies additional className', () => {
+    const customClass = 'my-custom-header-class';
+    render(<CalculatorHeader {...defaultProps} className={customClass} />);
+    // The className is applied to the root div of CalculatorHeader
+    // We need to select it, e.g., by its content or structure if no specific test-id is available
+    const headerElement = screen.getByText(defaultProps.title).closest('div.relative');
+    expect(headerElement).toHaveClass(customClass);
+  });
+});

--- a/src/app/components/__tests__/ResetButton.test.tsx
+++ b/src/app/components/__tests__/ResetButton.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ResetButton from '../ResetButton';
+import '@testing-library/jest-dom';
+
+describe('ResetButton', () => {
+  it('renders correctly', () => {
+    const handleClick = jest.fn();
+    render(<ResetButton onClick={handleClick} />);
+    const buttonElement = screen.getByRole('button', { name: /reset/i });
+    expect(buttonElement).toBeInTheDocument();
+    expect(buttonElement.querySelector('svg')).toBeInTheDocument(); // Check for XIcon
+  });
+
+  it('calls onClick handler when clicked', () => {
+    const handleClick = jest.fn();
+    render(<ResetButton onClick={handleClick} />);
+    const buttonElement = screen.getByRole('button', { name: /reset/i });
+    fireEvent.click(buttonElement);
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies additional className', () => {
+    const handleClick = jest.fn();
+    const customClass = "my-custom-class";
+    render(<ResetButton onClick={handleClick} className={customClass} />);
+    const buttonElement = screen.getByRole('button', { name: /reset/i });
+    expect(buttonElement).toHaveClass(customClass);
+  });
+});

--- a/src/app/features/SureBetCalculator2Way/SureBetCalculator2Way.tsx
+++ b/src/app/features/SureBetCalculator2Way/SureBetCalculator2Way.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useSurebet2Way } from "@/app/hooks/useSurebet2Way";
 import { Card, CardContent } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
+// import { Button } from "@/components/ui/button"; // Button import removed
 import BetSaveSection from "@/app/components/BetSaveSection";
 import OddsStakeRow from "@/app/components/OddsStakeRow";
 import TotalStakeRow from "@/app/components/TotalStakeRow";
@@ -96,7 +96,7 @@ const SureBetCalculator2Way: React.FC<SureBetCalculator2WayProps> = ({
 
   return (
     <Card className="w-full max-w-md mx-auto">
-      <CalculatorHeader title="2-Way Calculator" value={profitPercentage} />
+      <CalculatorHeader title="2-Way Calculator" value={profitPercentage} onReset={resetCalculatorState} />
       <CardContent className="relative grid gap-4 pt-4">
         <OddsStakeRow
           oddsType={odds1Type}
@@ -135,11 +135,7 @@ const SureBetCalculator2Way: React.FC<SureBetCalculator2WayProps> = ({
           setFixedField={setFixedField}
         />
         <ProfitDisplay profit={profit} />
-        <div className="flex justify-end">
-            <Button onClick={resetCalculatorState} variant="outline" size="sm">
-                Reset
-            </Button>
-        </div>
+        {/* Removed the old Reset button div */}
         <BetSaveSection
           betFields={{
             odds1,

--- a/src/app/features/SureBetCalculator2Way/__tests__/SureBetCalculator2Way.test.tsx
+++ b/src/app/features/SureBetCalculator2Way/__tests__/SureBetCalculator2Way.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SureBetCalculator2Way from '../SureBetCalculator2Way';
+import '@testing-library/jest-dom';
+import { CalculatorState2Way } from '@/app/page';
+
+// Mock CalculatorHeader to check if onReset is passed correctly
+jest.mock('@/app/components/CalculatorHeader', () => {
+  return jest.fn(({ title, value, onReset }) => (
+    <div>
+      <h1>{title}</h1>
+      <span>{value.toFixed(2)}%</span>
+      {onReset && <button aria-label="Reset" onClick={onReset}>HeaderReset</button>}
+    </div>
+  ));
+});
+
+// Mock BetSaveSection as its functionality is not the focus of this test
+jest.mock('@/app/components/BetSaveSection', () => {
+    return jest.fn(() => <div data-testid="bet-save-section">MockBetSaveSection</div>);
+});
+
+
+const initialCalculatorState: CalculatorState2Way = {
+  odds1: '',
+  odds2: '',
+  odds1Type: 'Decimal',
+  odds2Type: 'Decimal',
+  totalStake: '100',
+  stake1: 0,
+  stake2: 0,
+  fixedField: 'total',
+  name: '',
+};
+
+describe('SureBetCalculator2Way', () => {
+  let mockSetCalculatorState: jest.Mock;
+  let mockResetCalculatorState: jest.Mock;
+
+  beforeEach(() => {
+    mockSetCalculatorState = jest.fn();
+    mockResetCalculatorState = jest.fn();
+  });
+
+  const renderComponent = (props: Partial<React.ComponentProps<typeof SureBetCalculator2Way>> = {}) => {
+    const defaultProps: React.ComponentProps<typeof SureBetCalculator2Way> = {
+      calculatorState: initialCalculatorState,
+      setCalculatorState: mockSetCalculatorState,
+      resetCalculatorState: mockResetCalculatorState,
+      ...props,
+    };
+    return render(<SureBetCalculator2Way {...defaultProps} />);
+  };
+
+  it('renders correctly with initial state', () => {
+    renderComponent();
+    expect(screen.getByText('2-Way Calculator')).toBeInTheDocument();
+    // Check for OddsStakeRow components by their labels or unique IDs
+    expect(screen.getByLabelText('Odds 1')).toBeInTheDocument();
+    expect(screen.getByLabelText('Stake 1')).toBeInTheDocument();
+    expect(screen.getByLabelText('Odds 2')).toBeInTheDocument();
+    expect(screen.getByLabelText('Stake 2')).toBeInTheDocument();
+    expect(screen.getByLabelText('Total')).toBeInTheDocument(); // Changed "Total Stake" to "Total"
+    expect(screen.getByTestId('bet-save-section')).toBeInTheDocument();
+  });
+
+  it('calls resetCalculatorState when header reset button is clicked', () => {
+    renderComponent();
+    // The mock renders a button with aria-label="Reset" and text "HeaderReset"
+    // We should query by the aria-label as that's what the mock provides for accessibility
+    const resetButton = screen.getByRole('button', { name: /Reset/i });
+    fireEvent.click(resetButton);
+    expect(mockResetCalculatorState).toHaveBeenCalledTimes(1);
+  });
+
+  it('updates odds1 input field', () => {
+    renderComponent();
+    const odds1Input = screen.getByLabelText('Odds 1');
+    fireEvent.change(odds1Input, { target: { value: '2.0' } });
+    expect(mockSetCalculatorState).toHaveBeenCalledWith(expect.any(Function));
+    // To actually check the state update, you'd need to simulate the state update logic
+    // For now, we just check if the setter is called.
+  });
+
+  it('updates totalStake input field and sets fixedField to total', () => {
+    renderComponent();
+    const totalStakeInput = screen.getByLabelText('Total'); // Changed "Total Stake" to "Total"
+    fireEvent.change(totalStakeInput, { target: { value: '200' } });
+    expect(mockSetCalculatorState).toHaveBeenCalledWith(expect.any(Function));
+    // Example of how you might check the argument to setCalculatorState if needed:
+    // const lastCall = mockSetCalculatorState.mock.calls[mockSetCalculatorState.mock.calls.length - 1][0];
+    // expect(lastCall(initialCalculatorState)).toEqual(expect.objectContaining({ totalStake: '200', fixedField: 'total' }));
+  });
+
+  it('updates stake1 input field and sets fixedField to stake1', () => {
+    renderComponent({ calculatorState: { ...initialCalculatorState, fixedField: 'total' }});
+    const stake1Input = screen.getByLabelText('Stake 1');
+    // Need to enable the input first by clicking it if it's part of a radio group behavior
+    fireEvent.click(stake1Input); // This might be necessary if the input is disabled until selected
+    fireEvent.change(stake1Input, { target: { value: '50' } });
+    expect(mockSetCalculatorState).toHaveBeenCalledWith(expect.any(Function));
+    // Check the fixedField update
+    const lastCallArg = mockSetCalculatorState.mock.calls[mockSetCalculatorState.mock.calls.length - 1][0];
+    const newState = lastCallArg(initialCalculatorState);
+    expect(newState.stake1).toBe(50);
+    expect(newState.fixedField).toBe('stake1');
+  });
+
+});

--- a/src/app/features/SureBetCalculator3Way/SureBetCalculator3Way.tsx
+++ b/src/app/features/SureBetCalculator3Way/SureBetCalculator3Way.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useSurebet3Way } from "@/app/hooks/useSurebet3Way";
 import { Card, CardContent } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
+// import { Button } from "@/components/ui/button"; // Button import removed
 import BetSaveSection from "@/app/components/BetSaveSection";
 import OddsStakeRow from "@/app/components/OddsStakeRow";
 import TotalStakeRow from "@/app/components/TotalStakeRow";
@@ -90,7 +90,7 @@ const SureBetCalculator3Way: React.FC<SureBetCalculator3WayProps> = ({
 
   return (
     <Card className="w-full max-w-md mx-auto">
-      <CalculatorHeader title="3-Way Calculator" value={profitPercentage} />
+      <CalculatorHeader title="3-Way Calculator" value={profitPercentage} onReset={resetCalculatorState} />
       <CardContent className="relative grid gap-4 pt-4">
         <OddsStakeRow<StakeField3Way>
           oddsType={odds1Type} setOddsType={setOdds1Type}
@@ -124,11 +124,7 @@ const SureBetCalculator3Way: React.FC<SureBetCalculator3WayProps> = ({
           fixedField={fixedField} setFixedField={setFixedField}
         />
         <ProfitDisplay profit={profit} />
-        <div className="flex justify-end">
-            <Button onClick={resetCalculatorState} variant="outline" size="sm">
-                Reset
-            </Button>
-        </div>
+        {/* Removed the old Reset button div */}
         <BetSaveSection
           betFields={{
             odds1, odds2, odds3,

--- a/src/app/features/SureBetCalculator3Way/__tests__/SureBetCalculator3Way.test.tsx
+++ b/src/app/features/SureBetCalculator3Way/__tests__/SureBetCalculator3Way.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SureBetCalculator3Way from '../SureBetCalculator3Way';
+import '@testing-library/jest-dom';
+import { CalculatorState3Way } from '@/app/page';
+
+// Mock CalculatorHeader
+jest.mock('@/app/components/CalculatorHeader', () => {
+  return jest.fn(({ title, value, onReset }) => (
+    <div>
+      <h1>{title}</h1>
+      <span>{value.toFixed(2)}%</span>
+      {onReset && <button aria-label="Reset" onClick={onReset}>HeaderReset</button>}
+    </div>
+  ));
+});
+
+// Mock BetSaveSection
+jest.mock('@/app/components/BetSaveSection', () => {
+    return jest.fn(() => <div data-testid="bet-save-section">MockBetSaveSection</div>);
+});
+
+const initialCalculatorState: CalculatorState3Way = {
+  odds1: '',
+  odds2: '',
+  odds3: '',
+  odds1Type: 'Decimal',
+  odds2Type: 'Decimal',
+  odds3Type: 'Decimal',
+  totalStake: '100',
+  stake1: 0,
+  stake2: 0,
+  stake3: 0,
+  fixedField: 'total',
+  name: '',
+};
+
+describe('SureBetCalculator3Way', () => {
+  let mockSetCalculatorState: jest.Mock;
+  let mockResetCalculatorState: jest.Mock;
+
+  beforeEach(() => {
+    mockSetCalculatorState = jest.fn();
+    mockResetCalculatorState = jest.fn();
+  });
+
+  const renderComponent = (props: Partial<React.ComponentProps<typeof SureBetCalculator3Way>> = {}) => {
+    const defaultProps: React.ComponentProps<typeof SureBetCalculator3Way> = {
+      calculatorState: initialCalculatorState,
+      setCalculatorState: mockSetCalculatorState,
+      resetCalculatorState: mockResetCalculatorState,
+      ...props,
+    };
+    return render(<SureBetCalculator3Way {...defaultProps} />);
+  };
+
+  it('renders correctly with initial state', () => {
+    renderComponent();
+    expect(screen.getByText('3-Way Calculator')).toBeInTheDocument();
+    expect(screen.getByLabelText('Odds 1')).toBeInTheDocument();
+    expect(screen.getByLabelText('Stake 1')).toBeInTheDocument();
+    expect(screen.getByLabelText('Odds 2')).toBeInTheDocument();
+    expect(screen.getByLabelText('Stake 2')).toBeInTheDocument();
+    expect(screen.getByLabelText('Odds 3')).toBeInTheDocument();
+    expect(screen.getByLabelText('Stake 3')).toBeInTheDocument();
+    expect(screen.getByLabelText('Total')).toBeInTheDocument(); // Changed "Total Stake" to "Total"
+    expect(screen.getByTestId('bet-save-section')).toBeInTheDocument();
+  });
+
+  it('calls resetCalculatorState when header reset button is clicked', () => {
+    renderComponent();
+    const resetButton = screen.getByRole('button', { name: /Reset/i }); // Changed to query by aria-label
+    fireEvent.click(resetButton);
+    expect(mockResetCalculatorState).toHaveBeenCalledTimes(1);
+  });
+
+  it('updates odds1 input field', () => {
+    renderComponent();
+    const odds1Input = screen.getByLabelText('Odds 1');
+    fireEvent.change(odds1Input, { target: { value: '3.0' } });
+    expect(mockSetCalculatorState).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('updates stake1 input field and sets fixedField to stake1', () => {
+    renderComponent({ calculatorState: { ...initialCalculatorState, fixedField: 'total' }});
+    const stake1Input = screen.getByLabelText('Stake 1');
+    fireEvent.click(stake1Input);
+    fireEvent.change(stake1Input, { target: { value: '30' } });
+    expect(mockSetCalculatorState).toHaveBeenCalledWith(expect.any(Function));
+    const lastCallArg = mockSetCalculatorState.mock.calls[mockSetCalculatorState.mock.calls.length - 1][0];
+    const newState = lastCallArg(initialCalculatorState);
+    expect(newState.stake1).toBe(30);
+    expect(newState.fixedField).toBe('stake1');
+  });
+});

--- a/src/app/features/SureBetCalculator4Way/SureBetCalculator4Way.tsx
+++ b/src/app/features/SureBetCalculator4Way/SureBetCalculator4Way.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useSurebet4Way } from "@/app/hooks/useSurebet4Way";
 import { Card, CardContent } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
+// import { Button } from "@/components/ui/button"; // Button import removed
 import BetSaveSection from "@/app/components/BetSaveSection";
 import OddsStakeRow from "@/app/components/OddsStakeRow";
 import TotalStakeRow from "@/app/components/TotalStakeRow";
@@ -98,7 +98,7 @@ const SureBetCalculator4Way: React.FC<SureBetCalculator4WayProps> = ({
 
   return (
     <Card className="w-full max-w-md mx-auto">
-      <CalculatorHeader title="4-Way Calculator" value={profitPercentage} />
+      <CalculatorHeader title="4-Way Calculator" value={profitPercentage} onReset={resetCalculatorState} />
       <CardContent className="relative grid gap-4 pt-4">
         <OddsStakeRow<StakeField4Way>
           oddsType={odds1Type} setOddsType={setOdds1Type}
@@ -141,11 +141,7 @@ const SureBetCalculator4Way: React.FC<SureBetCalculator4WayProps> = ({
           fixedField={fixedField} setFixedField={setFixedField}
         />
         <ProfitDisplay profit={profit} />
-        <div className="flex justify-end">
-            <Button onClick={resetCalculatorState} variant="outline" size="sm">
-                Reset
-            </Button>
-        </div>
+        {/* Removed the old Reset button div */}
         <BetSaveSection
           betFields={{
             odds1, odds2, odds3, odds4,

--- a/src/app/features/SureBetCalculator4Way/__tests__/SureBetCalculator4Way.test.tsx
+++ b/src/app/features/SureBetCalculator4Way/__tests__/SureBetCalculator4Way.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SureBetCalculator4Way from '../SureBetCalculator4Way';
+import '@testing-library/jest-dom';
+import { CalculatorState4Way } from '@/app/page';
+
+// Mock CalculatorHeader
+jest.mock('@/app/components/CalculatorHeader', () => {
+  return jest.fn(({ title, value, onReset }) => (
+    <div>
+      <h1>{title}</h1>
+      <span>{value.toFixed(2)}%</span>
+      {onReset && <button aria-label="Reset" onClick={onReset}>HeaderReset</button>}
+    </div>
+  ));
+});
+
+// Mock BetSaveSection
+jest.mock('@/app/components/BetSaveSection', () => {
+    return jest.fn(() => <div data-testid="bet-save-section">MockBetSaveSection</div>);
+});
+
+const initialCalculatorState: CalculatorState4Way = {
+  odds1: '',
+  odds2: '',
+  odds3: '',
+  odds4: '',
+  odds1Type: 'Decimal',
+  odds2Type: 'Decimal',
+  odds3Type: 'Decimal',
+  odds4Type: 'Decimal',
+  totalStake: '100',
+  stake1: 0,
+  stake2: 0,
+  stake3: 0,
+  stake4: 0,
+  fixedField: 'total',
+  name: '',
+};
+
+describe('SureBetCalculator4Way', () => {
+  let mockSetCalculatorState: jest.Mock;
+  let mockResetCalculatorState: jest.Mock;
+
+  beforeEach(() => {
+    mockSetCalculatorState = jest.fn();
+    mockResetCalculatorState = jest.fn();
+  });
+
+  const renderComponent = (props: Partial<React.ComponentProps<typeof SureBetCalculator4Way>> = {}) => {
+    const defaultProps: React.ComponentProps<typeof SureBetCalculator4Way> = {
+      calculatorState: initialCalculatorState,
+      setCalculatorState: mockSetCalculatorState,
+      resetCalculatorState: mockResetCalculatorState,
+      ...props,
+    };
+    return render(<SureBetCalculator4Way {...defaultProps} />);
+  };
+
+  it('renders correctly with initial state', () => {
+    renderComponent();
+    expect(screen.getByText('4-Way Calculator')).toBeInTheDocument();
+    expect(screen.getByLabelText('Odds 1')).toBeInTheDocument();
+    expect(screen.getByLabelText('Stake 1')).toBeInTheDocument();
+    expect(screen.getByLabelText('Odds 2')).toBeInTheDocument();
+    expect(screen.getByLabelText('Stake 2')).toBeInTheDocument();
+    expect(screen.getByLabelText('Odds 3')).toBeInTheDocument();
+    expect(screen.getByLabelText('Stake 3')).toBeInTheDocument();
+    expect(screen.getByLabelText('Odds 4')).toBeInTheDocument();
+    expect(screen.getByLabelText('Stake 4')).toBeInTheDocument();
+    expect(screen.getByLabelText('Total')).toBeInTheDocument(); // Changed "Total Stake" to "Total"
+    expect(screen.getByTestId('bet-save-section')).toBeInTheDocument();
+  });
+
+  it('calls resetCalculatorState when header reset button is clicked', () => {
+    renderComponent();
+    const resetButton = screen.getByRole('button', { name: /Reset/i }); // Changed to query by aria-label
+    fireEvent.click(resetButton);
+    expect(mockResetCalculatorState).toHaveBeenCalledTimes(1);
+  });
+
+  it('updates odds1 input field', () => {
+    renderComponent();
+    const odds1Input = screen.getByLabelText('Odds 1');
+    fireEvent.change(odds1Input, { target: { value: '4.0' } });
+    expect(mockSetCalculatorState).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('updates stake1 input field and sets fixedField to stake1', () => {
+    renderComponent({ calculatorState: { ...initialCalculatorState, fixedField: 'total' }});
+    const stake1Input = screen.getByLabelText('Stake 1');
+    fireEvent.click(stake1Input);
+    fireEvent.change(stake1Input, { target: { value: '25' } });
+    expect(mockSetCalculatorState).toHaveBeenCalledWith(expect.any(Function));
+    const lastCallArg = mockSetCalculatorState.mock.calls[mockSetCalculatorState.mock.calls.length - 1][0];
+    const newState = lastCallArg(initialCalculatorState);
+    expect(newState.stake1).toBe(25);
+    expect(newState.fixedField).toBe('stake1');
+  });
+});


### PR DESCRIPTION
- Created a new ResetButton component with an X icon.
- Updated CalculatorHeader to include the ResetButton next to the title.
- Integrated the new reset functionality into 2-Way, 3-Way, and 4-Way calculators.
- Removed old reset buttons from calculator views.
- Added comprehensive tests for ResetButton, CalculatorHeader, and updated calculator component tests for the new reset mechanism.