### PR TITLE
fix(theme): Correct dark theme visuals and unify text color

### DIFF
--- a/src/app/__tests__/layout.test.tsx
+++ b/src/app/__tests__/layout.test.tsx
@@ -1,0 +1,220 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import RootLayout from '../layout'; // Adjust path as necessary
+
+// Mock child components to simplify layout testing
+jest.mock('../components/Calculator', () => () => <div data-testid="calculator" />);
+jest.mock('../components/CalculatorIcon', () => () => <div data-testid="calculator-icon" />);
+jest.mock('../components/ThemeSwitcherIcon', () => ({ theme, toggleTheme }: { theme: string, toggleTheme: () => void }) => (
+  <button data-testid="theme-switcher" onClick={toggleTheme}>
+    {theme === 'dark' ? 'Sun' : 'Moon'}
+  </button>
+));
+
+// Mock next/font
+jest.mock('next/font/google', () => ({
+  Geist: () => ({ variable: 'font-geist-sans', className: 'font-geist-sans-class' }),
+  Geist_Mono: () => ({ variable: 'font-geist-mono', className: 'font-geist-mono-class' }),
+}));
+
+describe('RootLayout', () => {
+  let mockLocalStorage: Storage;
+
+  const renderRootLayout = (children: React.ReactNode) => {
+    // To avoid the validateDOMNesting warning when rendering <html> directly,
+    // we can try to render into the document.documentElement or a fragment.
+    // However, React Testing Library's render typically appends to document.body.
+    // A common approach for full page components is to accept the warning if it doesn't break tests,
+    // or to test sections of the layout separately.
+
+    // For this case, we'll try to replace the document body with our component structure temporarily.
+    // This is quite invasive and might have side effects in more complex test suites.
+
+    // A less invasive way if RTL supports it directly for such cases:
+    // return render(<RootLayout>{children}</RootLayout>, { baseElement: document.documentElement });
+    // However, `baseElement` is usually for where to append. `container` might be more relevant if we want to control the direct parent.
+
+    // Let's try to render into a document fragment first, then attach parts to document.documentElement if needed for class checks.
+    // This might not fully solve the issue if RTL still wraps it.
+
+    // The most straightforward way to ensure the component behaves is to use the default render
+    // and acknowledge the warning, or to use a more E2E-like setup for full page renders.
+
+    // Given the constraints and the desire to remove the warning,
+    // we can try rendering into a DocumentFragment and then manually asserting on document.documentElement
+    // for class changes, as it's modified by the component.
+
+    // Let's stick to the standard render and see if a more targeted approach can be found later if this warning becomes problematic.
+    // The warning itself does not invalidate the test logic for theme switching.
+
+    // After further consideration, the warning is annoying but fixing it cleanly without
+    // potentially destabilizing tests or using overly complex workarounds is non-trivial
+    // with RTL for a component that renders the entire <html> structure.
+    // A pragmatic approach is often to acknowledge it if the tests are otherwise sound.
+
+    // However, let's try one common pattern: rendering into a custom container that is document.body
+    // This won't fix the div > html issue, but it's a step.
+    // The core issue is that `RootLayout` *is* the document root.
+
+    // The warning is `<html> cannot appear as a child of <div>`.
+    // This means RTL's default container (`div`) is the parent.
+    // If we could make `document.documentElement` the container, that might work.
+
+    // Let's try to use `document.body` as the container and see if we can manipulate `document.documentElement`
+    // This still might result in `body > html` if not careful.
+
+    // The most robust way to handle components that render `<html>` is often to
+    // not use RTL's default `render` directly on them, or to use a specialized setup.
+    // For now, we'll proceed with a small modification to see if it helps, but the warning might persist.
+
+    // Let's try rendering into `document.documentElement` after clearing it.
+    // This is highly unconventional for RTL and might break cleanup.
+    // A safer way is to use `baseElement` to ensure cleanup still works.
+
+    // If we render the component and it places <html>, and RTL puts it in a div,
+    // the structure is `div > html`. We want `html` at the root.
+    // RTL's `render` returns `container` which is the div.
+    // `baseElement` defaults to `document.body`.
+
+    // Let's try to provide `document.documentElement` as `container` for the render.
+    // This is not standard and might have issues with cleanup or other RTL utilities.
+    // A common pattern for testing full document components is to use `renderIntoDocument` from `react-dom/test-utils`
+    // and then wrap `document.documentElement` with `screen`. This is lower-level.
+
+    // Let's attempt a small structural change to how render is called for this specific suite.
+    // We will render into a fresh div, but the component itself renders <html>. The warning is likely to persist.
+    // The warning is annoying but doesn't break the tests.
+    // The solution is often to use Cypress/Playwright for such top-level component tests.
+
+    // For now, I will leave the render as is, as the warning does not prevent tests from passing
+    // and accurately testing the logic. A perfect solution for the warning without side-effects
+    // in RTL for a root `<html>` component is non-trivial.
+    // The key is that `document.documentElement.classList` is correctly updated.
+
+    // One last attempt: ensure the component is the only child of body.
+    // This still won't solve `div > html` if the component renders `html`.
+    // The warning is about the direct parent of `<html>` being a `<div>`.
+    // After much consideration, trying to force RTL to render `RootLayout` (which renders <html>)
+    // without a parent div in a way that's clean and doesn't affect RTL's cleanup logic
+    // is non-trivial. The warning, while annoying, doesn't break the test's ability to
+    // verify the theme switching logic, localStorage interaction, and class changes on document.documentElement.
+    // Forcing a container like `document.documentElement` can lead to other issues or require manual cleanup.
+    // Thus, we will proceed without altering the render method for now, acknowledging the warning.
+    return render(<RootLayout>{children}</RootLayout>);
+  };
+
+
+  beforeEach(() => {
+    // Clear and mock localStorage
+    mockLocalStorage = (function () {
+      let store: { [key: string]: string } = {};
+      return {
+        getItem: function (key: string) {
+          return store[key] || null;
+        },
+        setItem: function (key: string, value: string) {
+          store[key] = value.toString();
+        },
+        removeItem: function (key: string) {
+          delete store[key];
+        },
+        clear: function () {
+          store = {};
+        },
+        key: function (index: number) {
+          return Object.keys(store)[index] || null;
+        },
+        get length() {
+          return Object.keys(store).length;
+        },
+      };
+    })();
+    Object.defineProperty(window, 'localStorage', {
+      value: mockLocalStorage,
+      writable: true,
+    });
+    // Reset documentElement classList for each test
+    // Make sure documentElement exists
+    if (document && document.documentElement) {
+        document.documentElement.className = '';
+    }
+  });
+
+  afterEach(() => {
+    // Clean up documentElement classes to avoid interference between tests
+    if (document && document.documentElement) {
+        document.documentElement.className = '';
+    }
+    // RTL's cleanup should handle unmounting components
+  });
+
+  it('renders children and theme switcher', () => {
+    renderRootLayout(
+        <div>Test Child</div>
+    );
+    expect(screen.getByText('Test Child')).toBeInTheDocument();
+    expect(screen.getByTestId('theme-switcher')).toBeInTheDocument();
+  });
+
+  it('initializes with light theme by default and moon icon', () => {
+    renderRootLayout(
+        <div>Test Child</div>
+    );
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+    expect(screen.getByTestId('theme-switcher')).toHaveTextContent('Moon');
+  });
+
+  it('toggles theme to dark when switcher is clicked', () => {
+    renderRootLayout(
+        <div>Test Child</div>
+    );
+    const themeSwitcherButton = screen.getByTestId('theme-switcher');
+
+    act(() => {
+      fireEvent.click(themeSwitcherButton);
+    });
+
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(mockLocalStorage.getItem('theme')).toBe('dark');
+    expect(themeSwitcherButton).toHaveTextContent('Sun');
+  });
+
+  it('toggles theme back to light when switcher is clicked twice', () => {
+    renderRootLayout(
+        <div>Test Child</div>
+    );
+    const themeSwitcherButton = screen.getByTestId('theme-switcher');
+
+    act(() => {
+      fireEvent.click(themeSwitcherButton); // light -> dark
+    });
+    act(() => {
+      fireEvent.click(themeSwitcherButton); // dark -> light
+    });
+
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+    expect(mockLocalStorage.getItem('theme')).toBe('light');
+    expect(themeSwitcherButton).toHaveTextContent('Moon');
+  });
+
+  it('loads theme from localStorage on initial render', () => {
+    mockLocalStorage.setItem('theme', 'dark');
+    renderRootLayout(
+        <div>Test Child</div>
+    );
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(screen.getByTestId('theme-switcher')).toHaveTextContent('Sun');
+  });
+
+  // Test for Escape key closing calculator (existing functionality)
+  it('closes calculator on Escape key press', () => {
+    renderRootLayout(
+        <div>Test Child</div>
+    );
+    act(() => {
+      fireEvent.keyDown(document, { key: 'Escape', code: 'Escape' });
+    });
+    // Assertions would depend on how calculator visibility is exposed/tested
+  });
+});

--- a/src/app/components/ThemeSwitcherIcon.tsx
+++ b/src/app/components/ThemeSwitcherIcon.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Moon, Sun } from 'lucide-react';
+
+interface ThemeSwitcherIconProps {
+  theme: string;
+  toggleTheme: () => void;
+}
+
+const ThemeSwitcherIcon: React.FC<ThemeSwitcherIconProps> = ({ theme, toggleTheme }) => {
+  return (
+    <button
+      onClick={toggleTheme}
+      className="fixed bottom-4 left-4 z-50 p-3 bg-card text-card-foreground rounded-full shadow-lg hover:bg-primary hover:text-primary-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+      aria-label="Toggle theme"
+    >
+      {theme === 'dark' ? (
+        <Sun className="h-6 w-6" />
+      ) : (
+        <Moon className="h-6 w-6" />
+      )}
+    </button>
+  );
+};
+
+export default ThemeSwitcherIcon;

--- a/src/app/components/__tests__/ThemeSwitcherIcon.test.tsx
+++ b/src/app/components/__tests__/ThemeSwitcherIcon.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ThemeSwitcherIcon from '../ThemeSwitcherIcon';
+import { Sun, Moon } from 'lucide-react';
+
+// Mock lucide-react icons
+jest.mock('lucide-react', () => {
+  const originalModule = jest.requireActual('lucide-react');
+  return {
+    ...originalModule,
+    Sun: jest.fn(() => <svg data-testid="sun-icon" />),
+    Moon: jest.fn(() => <svg data-testid="moon-icon" />),
+  };
+});
+
+describe('ThemeSwitcherIcon', () => {
+  it('renders moon icon when theme is light', () => {
+    render(<ThemeSwitcherIcon theme="light" toggleTheme={() => {}} />);
+    expect(screen.getByTestId('moon-icon')).toBeInTheDocument();
+    expect(screen.queryByTestId('sun-icon')).not.toBeInTheDocument();
+  });
+
+  it('renders sun icon when theme is dark', () => {
+    render(<ThemeSwitcherIcon theme="dark" toggleTheme={() => {}} />);
+    expect(screen.getByTestId('sun-icon')).toBeInTheDocument();
+    expect(screen.queryByTestId('moon-icon')).not.toBeInTheDocument();
+  });
+
+  it('calls toggleTheme when clicked', () => {
+    const toggleThemeMock = jest.fn();
+    render(<ThemeSwitcherIcon theme="light" toggleTheme={toggleThemeMock} />);
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+    expect(toggleThemeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('has the correct aria-label', () => {
+    render(<ThemeSwitcherIcon theme="light" toggleTheme={() => {}} />);
+    expect(screen.getByLabelText('Toggle theme')).toBeInTheDocument();
+  });
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -45,24 +45,24 @@ body {
   }
   .dark {
     --background: 0 0% 3.9%;
-    --foreground: 0 0% 98%;
+    --foreground: 30 100% 50%; /* Orange color: HSL(30, 100%, 50%) */
     --card: 0 0% 3.9%;
-    --card-foreground: 0 0% 98%;
+    --card-foreground: 30 100% 50%; /* Orange color for card text */
     --popover: 0 0% 3.9%;
     --popover-foreground: 0 0% 98%;
     --primary: 145 56% 62%;
     --primary-foreground: 0 0% 9%;
     --secondary: 0 0% 14.9%;
-    --secondary-foreground: 0 0% 98%;
+    --secondary-foreground: 30 100% 50%; /* Orange for secondary text */
     --muted: 0 0% 14.9%;
-    --muted-foreground: 0 0% 63.9%;
+    --muted-foreground: 30 80% 50%; /* Slightly desaturated orange for muted text */
     --accent: 210 78% 55%;
-    --accent-foreground: 0 0% 98%;
+    --accent-foreground: 0 0% 98%; /* Keep accent foreground as is or change if needed */
     --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 14.9%;
-    --input: 0 0% 14.9%;
-    --ring: 0 0% 83.1%;
+    --destructive-foreground: 0 0% 98%; /* Keep destructive foreground as is */
+    --border: 0 0% 14.9%; /* Darker border for inputs, etc. */
+    --input: 0 0% 10%; /* Darker background for input fields */
+    --ring: 30 100% 50%; /* Orange for rings/focus indicators */
     --chart-1: 220 70% 50%;
     --chart-2: 160 60% 45%;
     --chart-3: 30 80% 55%;
@@ -86,5 +86,19 @@ body {
   body {
     @apply bg-background text-foreground;
   }
+  /* Ensure selects also use dark background and text colors */
+  .dark select {
+    background-color: hsl(var(--input));
+    color: hsl(var(--foreground)); /* Should now be orange */
+    border-color: hsl(var(--border));
+  }
+  /* Ensure placeholder text in inputs is also appropriately colored if needed */
+  .dark input::placeholder {
+    color: hsl(var(--muted-foreground)); /* Orange for placeholders */
+  }
+  .dark textarea::placeholder {
+    color: hsl(var(--muted-foreground)); /* Orange for placeholders */
+  }
+  /* Specific overrides for Radix select if needed, but Tailwind forms should cover it */
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import './globals.css';
 import React, { useState, useEffect } from 'react';
 import Calculator from './components/Calculator'; // Import Calculator
 import CalculatorIcon from './components/CalculatorIcon'; // Import CalculatorIcon
+import ThemeSwitcherIcon from './components/ThemeSwitcherIcon'; // Import ThemeSwitcherIcon
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -43,9 +44,32 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   const [isCalculatorOpen, setIsCalculatorOpen] = useState(false);
+  const [theme, setTheme] = useState('light'); // Default theme
+
+  // Load theme from localStorage on initial load
+  useEffect(() => {
+    const storedTheme = localStorage.getItem('theme');
+    if (storedTheme) {
+      setTheme(storedTheme);
+    }
+  }, []);
+
+  // Apply theme to HTML element and save to localStorage
+  useEffect(() => {
+    if (theme === 'dark') {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+    localStorage.setItem('theme', theme);
+  }, [theme]);
 
   const toggleCalculator = () => {
     setIsCalculatorOpen(!isCalculatorOpen);
+  };
+
+  const toggleTheme = () => {
+    setTheme((prevTheme) => (prevTheme === 'dark' ? 'light' : 'dark'));
   };
 
   // Close calculator on Escape key press
@@ -63,7 +87,7 @@ export default function RootLayout({
 
 
   return (
-    <html lang="en">
+    <html lang="en" className={theme}>
       <head>
         {/* It's generally recommended to put metadata tags directly in <head> or use Next.js <Head> component from 'next/head' for client components if needed,
             but for app router, metadata API is preferred. Since we made this a client component, this setup is a bit mixed.
@@ -75,8 +99,9 @@ export default function RootLayout({
         <link rel="apple-touch-icon" href="/favicon.png" />
         <link rel="manifest" href="/manifest.json" />
       </head>
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased bg-background text-foreground`}>
         {children}
+        <ThemeSwitcherIcon theme={theme} toggleTheme={toggleTheme} />
         <CalculatorIcon isCalculatorOpen={isCalculatorOpen} toggleCalculator={toggleCalculator} />
         <Calculator isOpen={isCalculatorOpen} onClose={toggleCalculator} />
       </body>


### PR DESCRIPTION
This commit addresses inconsistencies in the dark theme application and standardizes text color:

- Ensures `totalStake`, `name`, and `select` input fields have a dark background in dark mode, consistent with other inputs.
- Changes all primary, secondary, and muted text colors to orange (HSL 30, 100%, 50% and variations) in dark mode for a unified appearance.
- Updates focus ring colors to orange in dark mode.
- Modifies `--input` CSS variable for a darker input background in dark theme.
- Adds specific styles for `select` elements and input placeholders in dark mode.

These changes improve the visual coherence and usability of the dark theme.